### PR TITLE
User create endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'figaro'
 gem 'faraday'
 gem 'fast_jsonapi'
+gem 'bcrypt'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    bcrypt (3.1.16)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -184,6 +185,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  bcrypt
   bootsnap (>= 1.1.0)
   byebug
   capybara

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,10 +7,16 @@ class Api::V1::UsersController < ApplicationController
       @api_key = SecureRandom.base64
       break if User.where(api_key: @api_key) == []
     end
-    user = User.create(user_params.merge({api_key: @api_key}))
+    user = User.new(user_params.merge({api_key: @api_key}))
 
-    output = UsersSerializer.new(user)
-    render json: output
+    if user.save
+      output = UsersSerializer.new(user)
+      render json: output, :status => 201
+    else
+      output = Hash.new
+      output[:error] = user.errors.full_messages[0]
+      render json: output, :status => 400
+    end
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,21 @@
+require 'securerandom'
+
+class Api::V1::UsersController < ApplicationController
+  def create
+    # user creation
+    loop do
+      @api_key = SecureRandom.base64
+      break if User.where(api_key: @api_key) == []
+    end
+    user = User.create(user_params.merge({api_key: @api_key}))
+
+    output = UsersSerializer.new(user)
+    render json: output
+  end
+
+  private
+
+    def user_params
+      params.permit(:email, :password, :password_confirmation)
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates :email, uniqueness: true, presence: true
+  validates :password, confirmation: { case_sensitive: true }
+  validates_presence_of :email, :api_key
+
+end

--- a/app/poros/current_weather.rb
+++ b/app/poros/current_weather.rb
@@ -19,8 +19,8 @@ class CurrentWeather
     @datetime = convert_utc(data[:dt])
     @sunrise = convert_utc(data[:sunrise])
     @sunset = convert_utc(data[:sunset])
-    @temperature = data[:temp].round(1)
-    @feels_like = data[:feels_like].round(1)
+    @temperature = data[:temp].round(1).to_f
+    @feels_like = data[:feels_like].round(1).to_f
     @humidity = data[:humidity]
     @uvi = data[:uvi]
     @visibility = data[:visibility]

--- a/app/poros/day_weather.rb
+++ b/app/poros/day_weather.rb
@@ -15,8 +15,8 @@ class DayWeather
     @date = convert_utc_date(data[:dt])
     @sunrise = convert_utc(data[:sunrise])
     @sunset = convert_utc(data[:sunset])
-    @max_temp = data[:temp][:max].round(1)
-    @min_temp = data[:temp][:min].round(1)
+    @max_temp = data[:temp][:max].round(1).to_f
+    @min_temp = data[:temp][:min].round(1).to_f
     @conditions = data[:weather][0][:description]
     @icon = data[:weather][0][:icon]
   end

--- a/app/poros/hour_weather.rb
+++ b/app/poros/hour_weather.rb
@@ -10,7 +10,7 @@ class HourWeather
 
   def initialize(data)
     @time = convert_utc_time(data[:dt])
-    @temperature = data[:temp].round(1)
+    @temperature = data[:temp].round(1).to_f
     @wind_speed = "#{data[:wind_speed].round} mph"
     @wind_direction = convert_degrees(data[:wind_deg])
     @conditions = data[:weather][0][:description]

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,0 +1,4 @@
+class UsersSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :email, :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :forecast, only: [:index]
       resources :backgrounds, only: [:index]
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20210117184219_create_users.rb
+++ b/db/migrate/20210117184219_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :api_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_01_17_184219) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/requests/api/v1/forecast/index_spec.rb
+++ b/spec/requests/api/v1/forecast/index_spec.rb
@@ -30,15 +30,12 @@ describe 'forecast request' do
       expect(json[:data][:attributes][:current_weather][:temperature]).to be_a(Float)
       expect(json[:data][:attributes][:current_weather]).to have_key(:feels_like)
       expect(json[:data][:attributes][:current_weather][:feels_like]).to be_a(Float)
-
-      # these three can be ints or floats
       expect(json[:data][:attributes][:current_weather]).to have_key(:humidity)
-      expect(json[:data][:attributes][:current_weather][:humidity]).to be_a(Integer)
+      expect(json[:data][:attributes][:current_weather][:humidity]).to be_a(Numeric)
       expect(json[:data][:attributes][:current_weather]).to have_key(:uvi)
-      expect(json[:data][:attributes][:current_weather][:uvi]).to be_a(Integer)
+      expect(json[:data][:attributes][:current_weather][:uvi]).to be_a(Numeric)
       expect(json[:data][:attributes][:current_weather]).to have_key(:visibility)
-      expect(json[:data][:attributes][:current_weather][:visibility]).to be_a(Integer)
-
+      expect(json[:data][:attributes][:current_weather][:visibility]).to be_a(Numeric)
       expect(json[:data][:attributes][:current_weather]).to have_key(:conditions)
       expect(json[:data][:attributes][:current_weather][:conditions]).to be_a(String)
       expect(json[:data][:attributes][:current_weather]).to have_key(:icon)

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'users create request' do
+  it 'creates a user and returns an api key' do
+    payload = {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "password"
+    }
+
+    post '/api/v1/users', params: payload
+
+    user = User.where(email: payload[:email])
+
+    expect(response).to be_successful
+    expect(response).to be_a(Hash)
+    expect(response).to have_key(:data)
+    expect(response[:data]).to be_a(Hash)
+    expect(response[:data]).to have_key(:type)
+    expect(response[:data][:type]).to be_a(String)
+    expect(response[:data][:type]).to eq('users')
+    expect(response[:data]).to have_key(:id)
+    expect(response[:data][:id]).to be_a(String)
+    expect(response[:data][:id]).to eq(user.id.to_s)
+    expect(response[:data]).to have_key(:attributes)
+    expect(response[:data][:attributes]).to be_a(Hash)
+    expect(response[:data][:attributes]).to have_key('email')
+    expect(response[:data][:attributes][:email]).to be_a(String)
+    expect(response[:data][:attributes][:email]).to eq(user.email)
+    expect(response[:data][:attributes]).to have_key('api_key')
+    expect(response[:data][:attributes][:api_key]).to be_a(String)
+    expect(response[:data][:attributes][:api_key]).to eq(user.api_key)
+  end
+end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -10,25 +10,27 @@ describe 'users create request' do
 
     post '/api/v1/users', params: payload
 
-    user = User.where(email: payload[:email])
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    user = User.where(email: payload[:email])[0]
 
     expect(response).to be_successful
-    expect(response).to be_a(Hash)
-    expect(response).to have_key(:data)
-    expect(response[:data]).to be_a(Hash)
-    expect(response[:data]).to have_key(:type)
-    expect(response[:data][:type]).to be_a(String)
-    expect(response[:data][:type]).to eq('users')
-    expect(response[:data]).to have_key(:id)
-    expect(response[:data][:id]).to be_a(String)
-    expect(response[:data][:id]).to eq(user.id.to_s)
-    expect(response[:data]).to have_key(:attributes)
-    expect(response[:data][:attributes]).to be_a(Hash)
-    expect(response[:data][:attributes]).to have_key('email')
-    expect(response[:data][:attributes][:email]).to be_a(String)
-    expect(response[:data][:attributes][:email]).to eq(user.email)
-    expect(response[:data][:attributes]).to have_key('api_key')
-    expect(response[:data][:attributes][:api_key]).to be_a(String)
-    expect(response[:data][:attributes][:api_key]).to eq(user.api_key)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:data)
+    expect(json[:data]).to be_a(Hash)
+    expect(json[:data]).to have_key(:type)
+    expect(json[:data][:type]).to be_a(String)
+    expect(json[:data][:type]).to eq('users')
+    expect(json[:data]).to have_key(:id)
+    expect(json[:data][:id]).to be_a(String)
+    expect(json[:data][:id]).to eq(user.id.to_s)
+    expect(json[:data]).to have_key(:attributes)
+    expect(json[:data][:attributes]).to be_a(Hash)
+    expect(json[:data][:attributes]).to have_key(:email)
+    expect(json[:data][:attributes][:email]).to be_a(String)
+    expect(json[:data][:attributes][:email]).to eq(user.email)
+    expect(json[:data][:attributes]).to have_key(:api_key)
+    expect(json[:data][:attributes][:api_key]).to be_a(String)
+    expect(json[:data][:attributes][:api_key]).to eq(user.api_key)
   end
 end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -15,6 +15,7 @@ describe 'users create request' do
     user = User.where(email: payload[:email])[0]
 
     expect(response).to be_successful
+    expect(response.status).to eq(201)
     expect(json).to be_a(Hash)
     expect(json).to have_key(:data)
     expect(json[:data]).to be_a(Hash)
@@ -32,5 +33,108 @@ describe 'users create request' do
     expect(json[:data][:attributes]).to have_key(:api_key)
     expect(json[:data][:attributes][:api_key]).to be_a(String)
     expect(json[:data][:attributes][:api_key]).to eq(user.api_key)
+
+    expect(json[:data][:attributes]).to_not have_key(:password)
+    expect(json[:data][:attributes]).to_not have_key(:password_confirmation)
+    expect(json[:data][:attributes]).to_not have_key(:password_digest)
+  end
+
+  it 'returns 400 error with descriptive body if email already is in database' do
+    user = User.create!(
+      email: 'whatever@example.com',
+      password: 'password',
+      password_confirmation: 'password',
+      api_key: 'abc123'
+    )
+
+    payload = {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "password"
+    }
+
+    post '/api/v1/users', params: payload
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(400)
+
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:error)
+    expect(json[:error]).to eq('Email has already been taken')
+  end
+
+  it 'returns 400 error with descriptive body if password and confirmation do not match' do
+    payload = {
+      "email": "whatever@example.com",
+      "password": "password",
+      "password_confirmation": "pa$$word"
+    }
+
+    post '/api/v1/users', params: payload
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(400)
+
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:error)
+    expect(json[:error]).to eq("Password confirmation doesn't match Password")
+  end
+
+  it 'returns 400 error with descriptive body if email field is missing' do
+    payload = {
+      "password": "password",
+      "password_confirmation": "password"
+    }
+
+    post '/api/v1/users', params: payload
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(400)
+
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:error)
+    expect(json[:error]).to eq("Email can't be blank")
+  end
+
+  it 'returns 400 error with descriptive body if password field is missing' do
+    payload = {
+      "email": "whatever@example.com",
+      "password_confirmation": "password"
+    }
+
+    post '/api/v1/users', params: payload
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(400)
+
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:error)
+    expect(json[:error]).to eq("Password can't be blank")
+  end
+
+  xit 'returns 400 error with descriptive body if password_confirmation field is missing' do
+    payload = {
+      "email": "whatever@example.com",
+      "password": "password"
+    }
+
+    post '/api/v1/users', params: payload
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(400)
+
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:error)
+    expect(json[:error]).to eq("Password can't be blank")
   end
 end


### PR DESCRIPTION
This PR will:
* Add functionality and tests for POST '/users' endpoint
* Create user table in database
* Add sad path testing for endpoint

Notes:
* Missing password_confirmation test is not working and currently skipped - issue opened